### PR TITLE
Use internal chain reference for balance check

### DIFF
--- a/src/features/chain/services/blockchainServices.ts
+++ b/src/features/chain/services/blockchainServices.ts
@@ -136,7 +136,7 @@ export class Blockchain {
   }
 
   public getBalance(address: string): number {
-    const chain = blockchainInstance.getBlockchain()
+    const chain = this.chain
     let balance = 0
 
     for (const block of chain) {
@@ -188,5 +188,5 @@ export const blockchainServices = {
 
   getBalance: (address: string) => {
     return blockchainInstance.getBalance(address)
-  }
+  },
 }


### PR DESCRIPTION
## Summary
- ensure `Blockchain.getBalance` reads from the instance's chain

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6895b265bc8c832ca6d98b87b1a3c682